### PR TITLE
Fix cache warm throwing an error if no settings are defined

### DIFF
--- a/src/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/CacheWarmer/ProxyCacheWarmer.php
@@ -57,6 +57,9 @@ class ProxyCacheWarmer implements CacheWarmerInterface
 
         //Retrieve all defined settings classes
         $classes = $this->settingsRegistry->getSettingsClasses();
+        if (empty($classes)) {
+            return [];
+        }
 
         //And generate the proxy classes for them
         $this->proxyFactory->generateProxyClassFiles($classes);


### PR DESCRIPTION
Thanks for a helpful bundle!

If no Settings are defined, warming the cache will throw an error. This will always happen on the initial composer require for this bundle.

![image](https://github.com/jbtronics/settings-bundle/assets/1554882/4b044110-3c0f-4c17-92d1-757685dfae40)
