### PR TITLE
orm refetch detached entity before save

### DIFF
--- a/src/Storage/ORMStorageAdapter.php
+++ b/src/Storage/ORMStorageAdapter.php
@@ -130,6 +130,15 @@ final class ORMStorageAdapter implements StorageAdapterInterface
         //Retrieve the entity object
         $entity = $this->getEntityObject($entityManager, $key, $entityClass);
 
+        //reFetch if detached
+        if (!$entityManager->contains($entity)) {
+            $id = $entityManager->getClassMetadata($entityClass)->getIdentifierValues($entity);
+            if ([] !== $id) {
+                $entity = $entityManager->find($entityClass, $id) ?? $entity;
+                $this->cache[$entityClass][$key] = $entity;
+            }
+        }
+
         //Set the data
         $entity->setData($data);
 


### PR DESCRIPTION
I had problems using this bundle during batch processing, because as soon as a settings entity is detached with, for example, EntityManager->clear(), it is no longer possible to save with the ORMStorageAdapter. You get a duplicate entry exception because the ORMStorageAdapter tries to create the cached entity (now unmanaged) again, instead of updating it.