### PR TITLE
Allow symfony/var-exporter in version 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "symfony/translation-contracts": "^2.5|^3.0",
     "symfony/validator": "^6.4|^7.0|^8.0",
     "symfony/form": "^6.4|^7.0|^8.0",
-    "symfony/var-exporter": "^6.4|^7.0",
+    "symfony/var-exporter": "^6.4|^7.0|^8.0",
     "ergebnis/classy": "^1.6",
     "symfony/translation": "^7.0|^6.4|^8.0",
     "symfony/deprecation-contracts": "^3.4"


### PR DESCRIPTION
Right now, you can't install the package with Symfony 8 since it requires symfony/var-exporter in version 6 or 7.