### PR TITLE
symfony/var-exporter 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "symfony/translation-contracts": "^2.5|^3.0",
     "symfony/validator": "^6.4|^7.0|^8.0",
     "symfony/form": "^6.4|^7.0|^8.0",
-    "symfony/var-exporter": "^6.4|^7.0",
+    "symfony/var-exporter": "^6.4|^7.0|^8.0",
     "ergebnis/classy": "^1.6",
     "symfony/translation": "^7.0|^6.4|^8.0",
     "symfony/deprecation-contracts": "^3.4"

--- a/src/Manager/SettingsCloner.php
+++ b/src/Manager/SettingsCloner.php
@@ -32,6 +32,7 @@ use Jbtronics\SettingsBundle\Exception\ParameterDataNotCloneableException;
 use Jbtronics\SettingsBundle\Helper\PropertyAccessHelper;
 use Jbtronics\SettingsBundle\Metadata\MetadataManager;
 use Jbtronics\SettingsBundle\Metadata\ParameterMetadata;
+use Jbtronics\SettingsBundle\Proxy\LegacyProxyHelper;
 use Jbtronics\SettingsBundle\Proxy\ProxyFactoryInterface;
 use Jbtronics\SettingsBundle\Proxy\SettingsProxyInterface;
 use Jbtronics\SettingsBundle\Settings\CloneAndMergeAwareSettingsInterface;
@@ -137,7 +138,7 @@ final class SettingsCloner implements SettingsClonerInterface
                     continue;
                 }
 
-                if ($copyEmbedded instanceof SettingsProxyInterface && $this->isLegacyProxyUninitialized($copyEmbedded)) { //Fallback for older PHP versions
+                if ($copyEmbedded instanceof SettingsProxyInterface && LegacyProxyHelper::isLegacyProxyUninitialized($copyEmbedded)) { //Fallback for older PHP versions
                     continue;
                 }
 
@@ -195,23 +196,6 @@ final class SettingsCloner implements SettingsClonerInterface
 
         //Otherwise use the cloneable flag from the parameter metadata
         return $parameterMetadata->isCloneable();
-    }
-
-    /**
-     * Checks if a legacy (pre-PHP 8.4) proxy is still uninitialized.
-     */
-    private function isLegacyProxyUninitialized(object $instance): bool
-    {
-        if (!method_exists($instance, 'isLazyObjectInitialized')) {
-            return false;
-        }
-
-        $method = new \ReflectionMethod($instance, 'isLazyObjectInitialized');
-        if ($method->getNumberOfParameters() >= 1) {
-            return !$instance->isLazyObjectInitialized(false);
-        }
-
-        return !$instance->isLazyObjectInitialized();
     }
 
     /**

--- a/src/Manager/SettingsCloner.php
+++ b/src/Manager/SettingsCloner.php
@@ -37,7 +37,6 @@ use Jbtronics\SettingsBundle\Proxy\SettingsProxyInterface;
 use Jbtronics\SettingsBundle\Settings\CloneAndMergeAwareSettingsInterface;
 use Jbtronics\SettingsBundle\Settings\ResettableSettingsInterface;
 use PhpParser\Node\Param;
-use Symfony\Component\VarExporter\LazyObjectInterface;
 
 /**
  * @internal
@@ -138,7 +137,7 @@ final class SettingsCloner implements SettingsClonerInterface
                     continue;
                 }
 
-                if ($copyEmbedded instanceof SettingsProxyInterface && $copyEmbedded instanceof LazyObjectInterface && !$copyEmbedded->isLazyObjectInitialized()) { //Fallback for older PHP versions
+                if ($copyEmbedded instanceof SettingsProxyInterface && $this->isLegacyProxyUninitialized($copyEmbedded)) { //Fallback for older PHP versions
                     continue;
                 }
 
@@ -196,6 +195,23 @@ final class SettingsCloner implements SettingsClonerInterface
 
         //Otherwise use the cloneable flag from the parameter metadata
         return $parameterMetadata->isCloneable();
+    }
+
+    /**
+     * Checks if a legacy (pre-PHP 8.4) proxy is still uninitialized.
+     */
+    private function isLegacyProxyUninitialized(object $instance): bool
+    {
+        if (!method_exists($instance, 'isLazyObjectInitialized')) {
+            return false;
+        }
+
+        $method = new \ReflectionMethod($instance, 'isLazyObjectInitialized');
+        if ($method->getNumberOfParameters() >= 1) {
+            return !$instance->isLazyObjectInitialized(false);
+        }
+
+        return !$instance->isLazyObjectInitialized();
     }
 
     /**

--- a/src/Manager/SettingsManager.php
+++ b/src/Manager/SettingsManager.php
@@ -33,7 +33,6 @@ use Jbtronics\SettingsBundle\Metadata\MetadataManagerInterface;
 use Jbtronics\SettingsBundle\Metadata\ParameterMetadata;
 use Jbtronics\SettingsBundle\Proxy\ProxyFactoryInterface;
 use Jbtronics\SettingsBundle\Proxy\SettingsProxyInterface;
-use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -210,7 +209,7 @@ final class SettingsManager implements SettingsManagerInterface, ResetInterface
                 continue;
             }
 
-            if ($instance instanceof SettingsProxyInterface && $instance instanceof LazyObjectInterface && !$instance->isLazyObjectInitialized()) { //Fallback for older PHP versions
+            if ($instance instanceof SettingsProxyInterface && $this->isLegacyProxyUninitialized($instance)) { //Fallback for older PHP versions
                 continue;
             }
 
@@ -232,6 +231,23 @@ final class SettingsManager implements SettingsManagerInterface, ResetInterface
     {
         //Reset all cached settings classes, to trigger a reload on new requests
         $this->settings_by_class = [];
+    }
+
+    /**
+     * Checks if a legacy (pre-PHP 8.4) proxy is still uninitialized.
+     */
+    private function isLegacyProxyUninitialized(object $instance): bool
+    {
+        if (!method_exists($instance, 'isLazyObjectInitialized')) {
+            return false;
+        }
+
+        $method = new \ReflectionMethod($instance, 'isLazyObjectInitialized');
+        if ($method->getNumberOfParameters() >= 1) {
+            return !$instance->isLazyObjectInitialized(false);
+        }
+
+        return !$instance->isLazyObjectInitialized();
     }
 
     public function isEnvVarOverwritten(

--- a/src/Manager/SettingsManager.php
+++ b/src/Manager/SettingsManager.php
@@ -31,6 +31,7 @@ use Jbtronics\SettingsBundle\Helper\ProxyClassNameHelper;
 use Jbtronics\SettingsBundle\Metadata\EnvVarMode;
 use Jbtronics\SettingsBundle\Metadata\MetadataManagerInterface;
 use Jbtronics\SettingsBundle\Metadata\ParameterMetadata;
+use Jbtronics\SettingsBundle\Proxy\LegacyProxyHelper;
 use Jbtronics\SettingsBundle\Proxy\ProxyFactoryInterface;
 use Jbtronics\SettingsBundle\Proxy\SettingsProxyInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -209,7 +210,7 @@ final class SettingsManager implements SettingsManagerInterface, ResetInterface
                 continue;
             }
 
-            if ($instance instanceof SettingsProxyInterface && $this->isLegacyProxyUninitialized($instance)) { //Fallback for older PHP versions
+            if ($instance instanceof SettingsProxyInterface && LegacyProxyHelper::isLegacyProxyUninitialized($instance)) { //Fallback for older PHP versions
                 continue;
             }
 
@@ -233,22 +234,6 @@ final class SettingsManager implements SettingsManagerInterface, ResetInterface
         $this->settings_by_class = [];
     }
 
-    /**
-     * Checks if a legacy (pre-PHP 8.4) proxy is still uninitialized.
-     */
-    private function isLegacyProxyUninitialized(object $instance): bool
-    {
-        if (!method_exists($instance, 'isLazyObjectInitialized')) {
-            return false;
-        }
-
-        $method = new \ReflectionMethod($instance, 'isLazyObjectInitialized');
-        if ($method->getNumberOfParameters() >= 1) {
-            return !$instance->isLazyObjectInitialized(false);
-        }
-
-        return !$instance->isLazyObjectInitialized();
-    }
 
     public function isEnvVarOverwritten(
         object|string $settings,

--- a/src/Proxy/LegacyProxyHelper.php
+++ b/src/Proxy/LegacyProxyHelper.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Jbtronics\SettingsBundle\Proxy;
+
+/**
+ * Helper class providing utility methods for working with legacy proxies (pre-PHP 8.4).
+ * @internal
+ */
+final class LegacyProxyHelper
+{
+
+    /**
+     * Checks if a legacy (pre-PHP 8.4) proxy is still uninitialized.
+     * If the object is not a legacy proxy, it returns false.
+     */
+    public static function isLegacyProxyUninitialized(object $instance): bool
+    {
+        if (!method_exists($instance, 'isLazyObjectInitialized')) {
+            return false;
+        }
+
+        $method = new \ReflectionMethod($instance, 'isLazyObjectInitialized');
+        if ($method->getNumberOfParameters() >= 1) {
+            return !$instance->isLazyObjectInitialized(false);
+        }
+
+        return !$instance->isLazyObjectInitialized();
+    }
+}

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -66,7 +66,6 @@ PHP;
      */
     private readonly bool $useNativeGhostObject;
 
-
     public function __construct(
         private readonly string $proxyDir,
         private readonly string $proxyNamespace,

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -187,7 +187,12 @@ PHP;
      */
     protected function generateUseLazyGhostTrait(\ReflectionClass $reflClass): string
     {
-        $code = ProxyHelper::generateLazyGhost($reflClass);
+        $proxyHelper = new \ReflectionClass(ProxyHelper::class);
+        if (!$proxyHelper->hasMethod('generateLazyGhost')) {
+            throw new \RuntimeException('Lazy ghost proxy generation requires symfony/var-exporter < 8 or PHP 8.4+ native lazy objects.');
+        }
+
+        $code = (string) $proxyHelper->getMethod('generateLazyGhost')->invoke(null, $reflClass);
         $code = substr($code, 7 + (int) strpos($code, "\n{"));
         $code = substr($code, 0, (int) strpos($code, "\n}"));
         /*$code = str_replace('LazyGhostTrait;', str_replace("\n    ", "\n", 'LazyGhostTrait {

--- a/src/Proxy/SettingsProxyInterface.php
+++ b/src/Proxy/SettingsProxyInterface.php
@@ -28,16 +28,24 @@ declare(strict_types=1);
 
 namespace Jbtronics\SettingsBundle\Proxy;
 
-use \Symfony\Component\VarExporter\LazyObjectInterface;
-
 /**
  * This interface is implemented by proxies that lazy load settings.
  * @internal
  */
-interface SettingsProxyInterface extends LazyObjectInterface
-{
-    /**
-     * Marker for Proxy class names.
-     */
-    public const MARKER = '__JB__';
+if (interface_exists(\Symfony\Component\VarExporter\LazyObjectInterface::class)) {
+    interface SettingsProxyInterface extends \Symfony\Component\VarExporter\LazyObjectInterface
+    {
+        /**
+         * Marker for Proxy class names.
+         */
+        public const MARKER = '__JB__';
+    }
+} else {
+    interface SettingsProxyInterface
+    {
+        /**
+         * Marker for Proxy class names.
+         */
+        public const MARKER = '__JB__';
+    }
 }

--- a/tests/Manager/SettingsManagerTest.php
+++ b/tests/Manager/SettingsManagerTest.php
@@ -37,7 +37,6 @@ use Jbtronics\SettingsBundle\Tests\TestApplication\Settings\SimpleSettings;
 use Jbtronics\SettingsBundle\Tests\TestApplication\Settings\ValidatableSettings;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Validator\DataCollector\ValidatorDataCollector;
-use Symfony\Component\VarExporter\LazyObjectInterface;
 
 /**
  * The functional/integration test for the SettingsManager
@@ -160,9 +159,7 @@ class SettingsManagerTest extends KernelTestCase
         $this->assertEquals('default', $settings->simpleSettings->getValue1());
 
 
-        if ($settings->simpleSettings instanceof LazyObjectInterface) {
-            $this->assertTrue($settings->simpleSettings->isLazyObjectInitialized());
-        }
+        $this->assertTrue(LazyObjectTestHelper::isLazyObjectInitialized($settings->simpleSettings));
     }
 
     public function testGetEmbeddedCircular(): void

--- a/tests/Migrations/EnvVarToSettingsMigratorTest.php
+++ b/tests/Migrations/EnvVarToSettingsMigratorTest.php
@@ -44,7 +44,6 @@ use Jbtronics\SettingsBundle\Tests\TestApplication\Settings\SimpleSettings;
 use Jbtronics\SettingsBundle\Tests\TestApplication\Settings\ValidatableSettings;
 use Jbtronics\SettingsBundle\Tests\TestApplication\Settings\VersionedSettings;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\VarExporter\LazyObjectInterface;
 
 class EnvVarToSettingsMigratorTest extends KernelTestCase
 {

--- a/tests/Proxy/LazyObjectTestHelper.php
+++ b/tests/Proxy/LazyObjectTestHelper.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jbtronics\SettingsBundle\Tests\Proxy;
 
 use ReflectionClass;
-use Symfony\Component\VarExporter\LazyObjectInterface;
 
 final class LazyObjectTestHelper
 {
@@ -16,7 +15,13 @@ final class LazyObjectTestHelper
      */
     public static function isLazyObject(object $obj): bool
     {
-        if ($obj instanceof LazyObjectInterface){
+        if (interface_exists(\Symfony\Component\VarExporter\LazyObjectInterface::class)
+            && $obj instanceof \Symfony\Component\VarExporter\LazyObjectInterface
+        ) {
+            return true;
+        }
+
+        if (method_exists($obj, 'isLazyObjectInitialized')) {
             return true;
         }
 
@@ -36,8 +41,13 @@ final class LazyObjectTestHelper
      */
     public static function isLazyObjectInitialized(object $obj, bool $partial = false): bool
     {
-        if ($obj instanceof LazyObjectInterface){
-            return $obj->isLazyObjectInitialized($partial);
+        if (method_exists($obj, 'isLazyObjectInitialized')) {
+            $method = new \ReflectionMethod($obj, 'isLazyObjectInitialized');
+            if ($method->getNumberOfParameters() >= 1) {
+                return $obj->isLazyObjectInitialized($partial);
+            }
+
+            return $obj->isLazyObjectInitialized();
         }
 
         if (PHP_VERSION_ID >= 80400) {

--- a/tests/Proxy/ProxyFactoryTest.php
+++ b/tests/Proxy/ProxyFactoryTest.php
@@ -30,7 +30,6 @@ use Jbtronics\SettingsBundle\Proxy\ProxyFactoryInterface;
 use Jbtronics\SettingsBundle\Proxy\SettingsProxyInterface;
 use Jbtronics\SettingsBundle\Tests\TestApplication\Settings\SimpleSettings;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\VarExporter\LazyObjectInterface;
 
 class ProxyFactoryTest extends KernelTestCase
 {
@@ -64,7 +63,7 @@ class ProxyFactoryTest extends KernelTestCase
             $instance->setValue1('Initialized');
         };
 
-        /** @var LazyObjectInterface&SimpleSettings&SettingsProxyInterface $proxy */
+        /** @var SimpleSettings&SettingsProxyInterface $proxy */
         $proxy = $this->proxyFactory->createProxy(SimpleSettings::class, $initializer);
         $this->assertInstanceOf(SimpleSettings::class, $proxy);
 

--- a/tests/TestApplication/config/packages/doctrine.php
+++ b/tests/TestApplication/config/packages/doctrine.php
@@ -26,24 +26,30 @@
 declare(strict_types=1);
 
 
+$ormConfig = [
+    'auto_generate_proxy_classes' => true,
+    'naming_strategy' => 'doctrine.orm.naming_strategy.underscore_number_aware',
+    'auto_mapping' => true,
+    'mappings' => [
+        'TestEntities' => [
+            'is_bundle' => false,
+            'type' => 'attribute',
+            'dir' => '%kernel.project_dir%/src/Entity',
+            'prefix' => 'Jbtronics\SettingsBundle\Tests\TestApplication\Entity',
+            'alias' => 'app',
+        ],
+    ],
+];
+
+// Doctrine ORM supports native lazy objects on PHP 8.4+ via config.
+if (PHP_VERSION_ID >= 80400) {
+    $ormConfig['enable_native_lazy_objects'] = true;
+}
+
 $container->loadFromExtension('doctrine', [
     'dbal' => [
         'driver' => 'pdo_sqlite',
         'path' => '%kernel.cache_dir%/test_database.sqlite',
     ],
-
-    'orm' => [
-        'auto_generate_proxy_classes' => true,
-        'naming_strategy' => 'doctrine.orm.naming_strategy.underscore_number_aware',
-        'auto_mapping' => true,
-        'mappings' => [
-            'TestEntities' => [
-                'is_bundle' => false,
-                'type' => 'attribute',
-                'dir' => '%kernel.project_dir%/src/Entity',
-                'prefix' => 'Jbtronics\SettingsBundle\Tests\TestApplication\Entity',
-                'alias' => 'app',
-            ],
-        ],
-    ],
+    'orm' => $ormConfig,
 ]);


### PR DESCRIPTION
Just like in  https://github.com/jbtronics/settings-bundle/pull/33, the purpose of this PR is to add support for symfony/var-exporter 8. In order to maintain backward compatibility, I have kept the API unchanged.